### PR TITLE
Release v0.1.2

### DIFF
--- a/packages/fraiseql-data/pyproject.toml
+++ b/packages/fraiseql-data/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "fraiseql-data"
-version = "0.1.1"
+version = "0.1.2"
 description = "Schema-aware seed data generation for PostgreSQL"
 authors = [
     {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}

--- a/packages/fraiseql-data/src/fraiseql_data/introspection.py
+++ b/packages/fraiseql-data/src/fraiseql_data/introspection.py
@@ -111,7 +111,9 @@ class SchemaIntrospector:
                     c.column_default,
                     CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_pk,
                     COALESCE(c.is_identity, 'NO') as is_identity,
-                    c.udt_name
+                    c.udt_name,
+                    c.numeric_precision,
+                    c.numeric_scale
                 FROM information_schema.columns c
                 LEFT JOIN (
                     SELECT kcu.column_name
@@ -134,7 +136,7 @@ class SchemaIntrospector:
         return [
             ColumnInfo(
                 name=row[0],
-                pg_type=self._resolve_pg_type(row[1], row[6]),
+                pg_type=self._resolve_pg_type(row[1], row[6], row[7], row[8]),
                 is_nullable=row[2] == "YES",
                 default_value=row[3],
                 is_primary_key=row[4],
@@ -166,11 +168,19 @@ class SchemaIntrospector:
     }
 
     @classmethod
-    def _resolve_pg_type(cls, data_type: str, udt_name: str) -> str:
-        """Resolve the effective pg_type, expanding ARRAY with element info."""
+    def _resolve_pg_type(
+        cls,
+        data_type: str,
+        udt_name: str,
+        numeric_precision: int | None = None,
+        numeric_scale: int | None = None,
+    ) -> str:
+        """Resolve the effective pg_type, expanding ARRAY and numeric precision."""
         if data_type == "ARRAY" and udt_name.startswith("_"):
             element_type = cls._UDT_ELEMENT_TYPES.get(udt_name, udt_name.lstrip("_"))
             return f"{element_type}[]"
+        if data_type == "numeric" and numeric_precision is not None:
+            return f"numeric({numeric_precision},{numeric_scale or 0})"
         return data_type
 
     def get_unique_constraints(self, table_name: str) -> set[str]:

--- a/packages/fraiseql-data/tests/test_type_generators.py
+++ b/packages/fraiseql-data/tests/test_type_generators.py
@@ -194,6 +194,34 @@ class TestNumericPrecision:
             )
 
 
+class TestIntrospectorNumericType:
+    """Introspector resolves numeric(p,s) from precision/scale columns."""
+
+    def test_resolve_pg_type_numeric_with_precision_scale(self):
+        from fraiseql_data.introspection import SchemaIntrospector
+
+        result = SchemaIntrospector._resolve_pg_type("numeric", "numeric", 5, 4)
+        assert result == "numeric(5,4)"
+
+    def test_resolve_pg_type_numeric_without_precision(self):
+        from fraiseql_data.introspection import SchemaIntrospector
+
+        result = SchemaIntrospector._resolve_pg_type("numeric", "numeric", None, None)
+        assert result == "numeric"
+
+    def test_resolve_pg_type_numeric_scale_zero(self):
+        from fraiseql_data.introspection import SchemaIntrospector
+
+        result = SchemaIntrospector._resolve_pg_type("numeric", "numeric", 3, 0)
+        assert result == "numeric(3,0)"
+
+    def test_resolve_pg_type_non_numeric_unchanged(self):
+        from fraiseql_data.introspection import SchemaIntrospector
+
+        result = SchemaIntrospector._resolve_pg_type("integer", "int4", None, None)
+        assert result == "integer"
+
+
 class TestUnknownTypeWarning:
     """Unknown type warning."""
 

--- a/packages/fraiseql-uuid/pyproject.toml
+++ b/packages/fraiseql-uuid/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "fraiseql-uuid"
-version = "0.1.1"
+version = "0.1.2"
 description = "Structured UUID pattern library with encode/decode support"
 authors = [
     {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "fraiseql-seed"
-version = "0.1.1"
+version = "0.1.2"
 description = "FraiseQL Seed - UUID patterns and data generation for PostgreSQL"
 authors = [
     {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}

--- a/uv.lock
+++ b/uv.lock
@@ -333,7 +333,7 @@ provides-extras = ["dev", "cli", "confiture"]
 
 [[package]]
 name = "fraiseql-seed"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fraiseql-data" },
@@ -382,7 +382,7 @@ docs = [
 
 [[package]]
 name = "fraiseql-uuid"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/fraiseql-uuid" }
 dependencies = [
     { name = "pydantic" },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.1",
-  "commit": "ce8e8a9",
-  "branch": "feat/group-leader",
-  "timestamp": "2026-03-20T23:41:17Z"
+  "version": "0.1.2",
+  "commit": "8887f2e",
+  "branch": "fix/numeric-precision-introspection",
+  "timestamp": "2026-03-21T11:46:24Z"
 }


### PR DESCRIPTION
## Summary
- fix: introspector now passes numeric precision/scale to pg_type string, fixing `NumericValueOutOfRange` on constrained numeric columns (e.g. `numeric(5,4)` for VAT rates)
- Closes #3 (issue 3: numeric precision overflow)

## Changes
- Added `numeric_precision` and `numeric_scale` to introspector query
- `_resolve_pg_type()` synthesizes `"numeric(p,s)"` when precision/scale are present
- Added unit tests for `_resolve_pg_type()` numeric handling