### PR TITLE
Release fraiseql-data 0.1.4 to PyPI

### DIFF
--- a/packages/fraiseql-data/pyproject.toml
+++ b/packages/fraiseql-data/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "fraiseql-data"
-version = "0.1.3"
+version = "0.1.4"
 description = "Schema-aware seed data generation for PostgreSQL"
 authors = [
     {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}

--- a/packages/fraiseql-data/src/fraiseql_data/__init__.py
+++ b/packages/fraiseql-data/src/fraiseql_data/__init__.py
@@ -13,9 +13,9 @@ from fraiseql_data.generators.registry import (
     list_generators,
     register_generator,
 )
-from fraiseql_data.models import SeedRow, Seeds
+from fraiseql_data.models import SeedRow, Seeds, ValidationResult
 
-__version__ = "0.1.0"
+__version__ = "0.1.4"
 
 __all__ = [
     "BaseGenerator",
@@ -23,6 +23,7 @@ __all__ = [
     "SeedBuilder",
     "SeedRow",
     "Seeds",
+    "ValidationResult",
     "clear_generators",
     "list_generators",
     "register_generator",

--- a/packages/fraiseql-data/src/fraiseql_data/auto_deps.py
+++ b/packages/fraiseql-data/src/fraiseql_data/auto_deps.py
@@ -78,8 +78,8 @@ class AutoDependencyResolver:
 
             # Visit dependencies first (depth-first)
             for fk in fks:
-                # Skip self-referencing FKs
-                if fk.referenced_table != current_table:
+                # Skip self-referencing and cross-schema FKs
+                if fk.referenced_table != current_table and fk.referenced_schema is None:
                     visit(fk.referenced_table)
 
             # Add current table after dependencies (post-order)

--- a/packages/fraiseql-data/src/fraiseql_data/builder.py
+++ b/packages/fraiseql-data/src/fraiseql_data/builder.py
@@ -11,19 +11,19 @@ from psycopg import Connection
 # Note: Backend and introspector imports moved to __init__ for lazy loading
 from fraiseql_data.auto_deps import AutoDependencyResolver
 from fraiseql_data.exceptions import (
+    CircularDependencyError,
     ColumnGenerationError,
     ForeignKeyResolutionError,
+    MissingDependencyError,
     MultiColumnUniqueConstraintError,
     SelfReferenceError,
     UniqueConstraintError,
 )
 from fraiseql_data.generators import FakerGenerator, TrinityGenerator
 from fraiseql_data.generators.groups import GroupRegistry
-from fraiseql_data.models import SeedPlan, Seeds, TableInfo
+from fraiseql_data.models import SeedPlan, Seeds, TableInfo, ValidationResult
 
 logger = logging.getLogger(__name__)
-
-_seed_common_warned = False
 
 # Constants for generation logic
 MAX_UNIQUE_RETRIES = 10  # Maximum attempts to generate unique value
@@ -216,8 +216,10 @@ class SeedBuilder:
                 - Path to YAML/JSON file
                 - Path to directory (auto-detects format and environment)
                 - SeedCommon instance
-                - None (shows warning, not recommended)
-            validate_seed_common: Validate FK references (default: True)
+                - None (empty baseline, fine for simple use cases)
+            validate_seed_common: Validate FK references in provided
+                seed_common files (default: True). Has no effect when
+                seed_common is None.
             trinity_enabled: Enable Trinity extension for deterministic
                 PK allocation (default: False)
             trinity_tenant_id: Tenant ID for multi-tenant Trinity
@@ -273,16 +275,6 @@ class SeedBuilder:
         from fraiseql_data.seed_common import SeedCommon, SeedCommonValidationError
 
         if seed_common is None:
-            global _seed_common_warned  # noqa: PLW0603
-            if validate_seed_common and not _seed_common_warned:
-                _seed_common_warned = True
-                logger.warning(
-                    "No seed common defined. UUID collisions may occur when "
-                    "creating multiple SeedBuilder instances.\n"
-                    "Recommendation: Define seed common baseline:\n"
-                    "  SeedBuilder(..., seed_common='db/')\n"
-                    "This warning will become an error in v2.0."
-                )
             self._seed_common = SeedCommon(instance_offsets={}, data=None)
         elif isinstance(seed_common, SeedCommon):
             self._seed_common = seed_common
@@ -381,6 +373,76 @@ class SeedBuilder:
             )
         )
         return self
+
+    def validate(self) -> ValidationResult:
+        """
+        Validate the current seed plan without executing.
+
+        Checks that all FK dependencies are satisfied (or overridden)
+        and that the dependency graph has no circular dependencies.
+
+        Returns:
+            ValidationResult with is_valid, errors, and plan_summary
+
+        Example:
+            >>> result = builder.validate()
+            >>> if not result.is_valid:
+            ...     for err in result.errors:
+            ...         print(err)
+        """
+        errors: list[str] = []
+
+        # Build overridden FK map
+        overridden_fks: dict[str, set[str]] = {}
+        for plan in self._plan:
+            if plan.overrides:
+                try:
+                    table_info = self.introspector.get_table_info(plan.table)
+                except Exception as e:
+                    errors.append(str(e))
+                    continue
+                fk_cols_with_override = {
+                    fk.column for fk in table_info.foreign_keys if fk.column in plan.overrides
+                }
+                if fk_cols_with_override:
+                    overridden_fks[plan.table] = fk_cols_with_override
+
+        # Validate dependencies
+        try:
+            graph = self.introspector.get_dependency_graph()
+            graph.validate_plan([p.table for p in self._plan], overridden_fks)
+        except (
+            MissingDependencyError,
+            CircularDependencyError,
+        ) as e:
+            errors.append(str(e))
+
+        # Build plan summary in dependency order
+        plan_summary: list[dict[str, Any]] = []
+        try:
+            sorted_tables = self.introspector.topological_sort()
+            plan_by_table = {p.table: p for p in self._plan}
+            for table in sorted_tables:
+                if table in plan_by_table:
+                    p = plan_by_table[table]
+                    plan_summary.append(
+                        {
+                            "table": p.table,
+                            "count": p.count,
+                            "strategy": p.strategy,
+                        }
+                    )
+        except CircularDependencyError:
+            # Already captured above; provide unsorted summary
+            plan_summary.extend(
+                {"table": p.table, "count": p.count, "strategy": p.strategy} for p in self._plan
+            )
+
+        return ValidationResult(
+            is_valid=len(errors) == 0,
+            errors=errors,
+            plan_summary=plan_summary,
+        )
 
     def execute(self) -> Seeds:
         """
@@ -542,6 +604,51 @@ class SeedBuilder:
         """
         return BatchContext(self)
 
+    def seed_all(
+        self,
+        *,
+        default_count: int = 5,
+        counts: dict[str, int] | None = None,
+        overrides: dict[str, dict[str, Any]] | None = None,
+        exclude: set[str] | list[str] | None = None,
+    ) -> Seeds:
+        """
+        Auto-discover all tables, sort by dependencies, and seed.
+
+        Args:
+            default_count: Default row count per table (default: 5)
+            counts: Per-table count overrides
+            overrides: Per-table column overrides
+            exclude: Tables to skip (e.g. audit/migration tables)
+
+        Returns:
+            Seeds with generated data for all tables
+
+        Example:
+            >>> seeds = builder.seed_all(
+            ...     default_count=10,
+            ...     counts={"tb_order": 100},
+            ...     exclude={"tb_audit_log"},
+            ... )
+        """
+        counts = counts or {}
+        overrides = overrides or {}
+        exclude_set = set(exclude) if exclude else set()
+
+        # Discover and sort all tables
+        sorted_names = self.introspector.topological_sort()
+
+        for name in sorted_names:
+            if name in exclude_set:
+                continue
+            self.add(
+                name,
+                count=counts.get(name, default_count),
+                overrides=overrides.get(name, {}),
+            )
+
+        return self.execute()
+
     def set_table_schema(self, table_name: str, table_info: TableInfo) -> None:
         """
         Set table schema manually (for staging backend only).
@@ -608,6 +715,9 @@ class SeedBuilder:
         import random
 
         faker_gen = FakerGenerator()
+
+        # Cache for cross-schema FK values (schema.table.column → list of values)
+        cross_schema_cache: dict[str, list[Any]] = {}
 
         # Build Trinity context if enabled
         trinity_context = None
@@ -795,6 +905,41 @@ class SeedBuilder:
                             row[col.name] = parent_row[fk.referenced_column]
                         continue
 
+                    # Cross-schema FK: query external table for values
+                    if fk.referenced_schema is not None:
+                        cache_key = (
+                            f"{fk.referenced_schema}.{fk.referenced_table}.{fk.referenced_column}"
+                        )
+                        if cache_key not in cross_schema_cache:
+                            if self.conn is None:
+                                raise ForeignKeyResolutionError(
+                                    fk.column,
+                                    f"{fk.referenced_schema}.{fk.referenced_table} "
+                                    f"(cross-schema FKs require a database connection; "
+                                    f"use overrides for staging backend)",
+                                )
+                            from psycopg import sql
+
+                            with self.conn.cursor() as cur:
+                                query = sql.SQL("SELECT {col} FROM {schema}.{table}").format(
+                                    col=sql.Identifier(fk.referenced_column),
+                                    schema=sql.Identifier(fk.referenced_schema),
+                                    table=sql.Identifier(fk.referenced_table),
+                                )
+                                cur.execute(query)
+                                values = [r[0] for r in cur.fetchall()]
+                            if not values:
+                                if col.is_nullable:
+                                    row[col.name] = None
+                                    continue
+                                raise ForeignKeyResolutionError(
+                                    fk.column,
+                                    f"{fk.referenced_schema}.{fk.referenced_table} (no rows found)",
+                                )
+                            cross_schema_cache[cache_key] = values
+                        row[col.name] = random.choice(cross_schema_cache[cache_key])
+                        continue
+
                     # Regular FK: validate parent data exists
                     if fk.referenced_table not in generated_data:
                         raise ForeignKeyResolutionError(fk.column, fk.referenced_table)
@@ -811,7 +956,12 @@ class SeedBuilder:
 
                 # Generate using strategy
                 if plan.strategy == "faker":
-                    value = faker_gen.generate(col.name, col.pg_type)
+                    value = faker_gen.generate(
+                        col.name,
+                        col.pg_type,
+                        max_length=col.max_length,
+                        is_nullable=col.is_nullable,
+                    )
                 else:
                     # Try custom generator from registry
                     from fraiseql_data.generators.registry import get_generator
@@ -841,7 +991,12 @@ class SeedBuilder:
                     # Retry if collision
                     retries = 0
                     while value in unique_values[col.name] and retries < MAX_UNIQUE_RETRIES:
-                        value = faker_gen.generate(col.name, col.pg_type)
+                        value = faker_gen.generate(
+                            col.name,
+                            col.pg_type,
+                            max_length=col.max_length,
+                            is_nullable=col.is_nullable,
+                        )
                         retries += 1
 
                     if retries == MAX_UNIQUE_RETRIES:

--- a/packages/fraiseql-data/src/fraiseql_data/dependency.py
+++ b/packages/fraiseql-data/src/fraiseql_data/dependency.py
@@ -13,6 +13,8 @@ class DependencyGraph:
         self._tables: set[str] = set()
         # table -> dep -> set of FK column names that create this dependency
         self._fk_columns: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+        # table -> set of external (cross-schema) references like "schema.table"
+        self._external_deps: dict[str, set[str]] = defaultdict(set)
 
     def add_table(self, table: str) -> None:
         """Add a table to the graph."""
@@ -34,6 +36,18 @@ class DependencyGraph:
         self._graph[table].add(depends_on)
         if fk_column is not None:
             self._fk_columns[table][depends_on].add(fk_column)
+
+    def add_external_dependency(self, table: str, external_ref: str) -> None:
+        """Register an external (cross-schema) dependency.
+
+        External dependencies are not included in the graph and are assumed
+        to already exist in the database.
+
+        Args:
+            table: Table that has the FK.
+            external_ref: Qualified reference like "other_schema.parent_table".
+        """
+        self._external_deps[table].add(external_ref)
 
     def get_dependencies(self, table: str) -> list[str]:
         """Get all tables that this table depends on."""

--- a/packages/fraiseql-data/src/fraiseql_data/generators/faker_generator.py
+++ b/packages/fraiseql-data/src/fraiseql_data/generators/faker_generator.py
@@ -178,6 +178,28 @@ class FakerGenerator:
         "url": _pool_url,
         "description": _pool_text_200,
         "bio": _pool_text_300,
+        # Short-varchar friendly mappings
+        "lang": lambda: random.choice(["en", "fr", "de", "es", "nl", "it", "pt"]),
+        "language": lambda: random.choice(["en", "fr", "de", "es", "nl", "it", "pt"]),
+        "locale": lambda: random.choice(
+            [
+                "en_US",
+                "fr_FR",
+                "de_DE",
+                "es_ES",
+                "nl_NL",
+                "it_IT",
+                "pt_BR",
+            ]
+        ),
+        "domain_tld": lambda: random.choice([".com", ".fr", ".de", ".nl", ".io"]),
+        "tld": lambda: random.choice([".com", ".fr", ".de", ".nl", ".io"]),
+    }
+
+    # Suffix patterns: column names ending with these get the mapped generator
+    _COLUMN_SUFFIX_MAPPINGS: ClassVar[dict[str, Any]] = {
+        "_phone": _pool_phone,
+        "_email": _pool_email,
     }
 
     # Type-based fallbacks (fast paths where possible)
@@ -214,6 +236,12 @@ class FakerGenerator:
         "bytea": _fast_bytea,
         # Array types (generic fallback)
         "ARRAY": lambda: [_pool_word() for _ in range(3)],
+        # Common USER-DEFINED types (resolved via udt_name)
+        "ltree": lambda: ".".join(fake.words(nb=random.randint(2, 4))),
+        "citext": _pool_text_50,
+        "hstore": lambda: (
+            f'"key1"=>"val{random.randint(1, 999)}", "key2"=>"val{random.randint(1, 999)}"'
+        ),
     }
 
     # Regex for numeric(precision, scale)
@@ -221,6 +249,27 @@ class FakerGenerator:
 
     # Regex for array types (e.g., "integer[]", "text[]")
     _ARRAY_RE = re.compile(r"^(.+)\[\]$")
+
+    # Soft-delete column name patterns — nullable timestamps matching these return None
+    _SOFT_DELETE_NAMES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "deleted_at",
+            "soft_deleted_at",
+            "removed_at",
+            "archived_at",
+        }
+    )
+
+    _SOFT_DELETE_TYPES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "timestamp without time zone",
+            "timestamp with time zone",
+            "timestamptz",
+        }
+    )
+
+    # Pluggable UDT registry for user-registered generators
+    _custom_udt_generators: ClassVar[dict[str, Any]] = {}
 
     # Base type generators for array element generation
     _ARRAY_ELEMENT_GENERATORS: ClassVar[dict[str, Any]] = {
@@ -234,7 +283,27 @@ class FakerGenerator:
         "boolean": _fast_bool,
     }
 
-    def generate(self, column_name: str, pg_type: str) -> Any:
+    @classmethod
+    def register_udt_generator(cls, udt_name: str, generator: Any) -> None:
+        """Register a custom generator for a USER-DEFINED PostgreSQL type.
+
+        Args:
+            udt_name: The UDT name as reported by PostgreSQL (e.g., 'ltree').
+            generator: A callable that returns a value for the type.
+
+        Example:
+            >>> FakerGenerator.register_udt_generator("ltree", lambda: "root.node_1")
+        """
+        cls._custom_udt_generators[udt_name] = generator
+
+    def generate(
+        self,
+        column_name: str,
+        pg_type: str,
+        *,
+        max_length: int | None = None,
+        is_nullable: bool = False,
+    ) -> Any:
         """
         Generate data for a column based on name and type.
 
@@ -253,32 +322,54 @@ class FakerGenerator:
             >>> gen.generate('created_at', 'timestamptz')
             datetime(2024, 1, 15, 10, 30, 0)
         """
-        # Try column name mapping first
+        # Soft-delete heuristic: nullable timestamp columns with deletion names → None
+        if (
+            is_nullable
+            and pg_type in self._SOFT_DELETE_TYPES
+            and (column_name in self._SOFT_DELETE_NAMES or column_name.endswith("_deleted_at"))
+        ):
+            return None
+
+        # Try column name mapping first (exact match)
         if column_name in self.COLUMN_MAPPINGS:
-            return self.COLUMN_MAPPINGS[column_name]()
-
+            value = self.COLUMN_MAPPINGS[column_name]()
+        # Try suffix-based column name matching (e.g., mobile_phone → phone)
+        elif suffix_gen := next(
+            (
+                gen
+                for suffix, gen in self._COLUMN_SUFFIX_MAPPINGS.items()
+                if column_name.endswith(suffix)
+            ),
+            None,
+        ):
+            value = suffix_gen()
         # Fall back to type-based generation
-        if pg_type in self.TYPE_FALLBACKS:
-            return self.TYPE_FALLBACKS[pg_type]()
-
+        elif pg_type in self.TYPE_FALLBACKS:
+            value = self.TYPE_FALLBACKS[pg_type]()
         # Check for numeric(precision, scale)
-        numeric_match = self._NUMERIC_RE.match(pg_type)
-        if numeric_match:
+        elif numeric_match := self._NUMERIC_RE.match(pg_type):
             precision, scale = int(numeric_match.group(1)), int(numeric_match.group(2))
             max_val = 10 ** (precision - scale) - 10**-scale
             return round(random.uniform(0, max_val), scale)
-
         # Check for array types (e.g., "integer[]")
-        array_match = self._ARRAY_RE.match(pg_type)
-        if array_match:
+        elif array_match := self._ARRAY_RE.match(pg_type):
             base_type = array_match.group(1)
             element_gen = self._ARRAY_ELEMENT_GENERATORS.get(base_type, _pool_word)
             return [element_gen() for _ in range(3)]
+        # Check custom UDT registry
+        elif pg_type in self._custom_udt_generators:
+            value = self._custom_udt_generators[pg_type]()
+        else:
+            # Unknown type: warn and fall back to text
+            logger.warning(
+                "Unknown PostgreSQL type '%s' for column '%s', falling back to text",
+                pg_type,
+                column_name,
+            )
+            value = _pool_text_50()
 
-        # Unknown type: warn and fall back to text
-        logger.warning(
-            "Unknown PostgreSQL type '%s' for column '%s', falling back to text",
-            pg_type,
-            column_name,
-        )
-        return _pool_text_50()
+        # Truncate text values to respect varchar length constraints
+        if max_length is not None and isinstance(value, str) and len(value) > max_length:
+            value = value[:max_length]
+
+        return value

--- a/packages/fraiseql-data/src/fraiseql_data/introspection.py
+++ b/packages/fraiseql-data/src/fraiseql_data/introspection.py
@@ -113,7 +113,8 @@ class SchemaIntrospector:
                     COALESCE(c.is_identity, 'NO') as is_identity,
                     c.udt_name,
                     c.numeric_precision,
-                    c.numeric_scale
+                    c.numeric_scale,
+                    c.character_maximum_length
                 FROM information_schema.columns c
                 LEFT JOIN (
                     SELECT kcu.column_name
@@ -142,6 +143,7 @@ class SchemaIntrospector:
                 is_primary_key=row[4],
                 is_unique=row[0] in unique_columns,
                 is_identity=row[5] == "YES",
+                max_length=row[9],
             )
             for row in rows
         ]
@@ -181,6 +183,8 @@ class SchemaIntrospector:
             return f"{element_type}[]"
         if data_type == "numeric" and numeric_precision is not None:
             return f"numeric({numeric_precision},{numeric_scale or 0})"
+        if data_type == "USER-DEFINED":
+            return udt_name
         return data_type
 
     def get_unique_constraints(self, table_name: str) -> set[str]:
@@ -349,14 +353,14 @@ class SchemaIntrospector:
                 SELECT
                     kcu.column_name,
                     ccu.table_name AS foreign_table_name,
-                    ccu.column_name AS foreign_column_name
+                    ccu.column_name AS foreign_column_name,
+                    ccu.table_schema AS foreign_table_schema
                 FROM information_schema.table_constraints AS tc
                 JOIN information_schema.key_column_usage AS kcu
                   ON tc.constraint_name = kcu.constraint_name
                   AND tc.table_schema = kcu.table_schema
                 JOIN information_schema.constraint_column_usage AS ccu
                   ON ccu.constraint_name = tc.constraint_name
-                  AND ccu.table_schema = tc.table_schema
                 WHERE tc.constraint_type = 'FOREIGN KEY'
                   AND tc.table_schema = %s
                   AND tc.table_name = %s
@@ -370,7 +374,8 @@ class SchemaIntrospector:
                 column=row[0],
                 referenced_table=row[1],
                 referenced_column=row[2],
-                is_self_referencing=row[1] == table_name,
+                referenced_schema=row[3] if row[3] != self.schema else None,
+                is_self_referencing=row[1] == table_name and row[3] == self.schema,
             )
             for row in rows
         ]
@@ -386,8 +391,15 @@ class SchemaIntrospector:
         for table in tables:
             graph.add_table(table.name)
             for fk in table.foreign_keys:
-                # Skip self-references (don't add to dependency graph)
-                if not fk.is_self_referencing:
+                if fk.is_self_referencing:
+                    continue
+                if fk.referenced_schema is not None:
+                    # Cross-schema FK: register as external, don't add graph edge
+                    graph.add_external_dependency(
+                        table.name,
+                        f"{fk.referenced_schema}.{fk.referenced_table}",
+                    )
+                else:
                     graph.add_dependency(table.name, fk.referenced_table, fk_column=fk.column)
 
         self._dependency_graph_cache = graph
@@ -465,12 +477,23 @@ class MockIntrospector:
             # Add table
             graph.add_table(table_name)
 
-            # Add FK dependencies (skip self-references)
+            # Add FK dependencies (skip self-references and cross-schema)
             for fk in table_info.foreign_keys:
-                if not fk.is_self_referencing:
+                if fk.is_self_referencing:
+                    continue
+                if fk.referenced_schema is not None:
+                    graph.add_external_dependency(
+                        table_name,
+                        f"{fk.referenced_schema}.{fk.referenced_table}",
+                    )
+                else:
                     graph.add_dependency(table_name, fk.referenced_table, fk_column=fk.column)
 
         return graph
+
+    def get_tables(self) -> list[TableInfo]:
+        """Get all registered tables."""
+        return list(self._schemas.values())
 
     def topological_sort(self) -> list[str]:
         """

--- a/packages/fraiseql-data/src/fraiseql_data/models.py
+++ b/packages/fraiseql-data/src/fraiseql_data/models.py
@@ -30,6 +30,7 @@ class ColumnInfo:
     default_value: str | None = None
     is_unique: bool = False
     is_identity: bool = False
+    max_length: int | None = None
 
 
 @dataclass
@@ -47,6 +48,7 @@ class ForeignKeyInfo:
     column: str
     referenced_table: str
     referenced_column: str
+    referenced_schema: str | None = None
     is_self_referencing: bool = False
 
 
@@ -208,14 +210,22 @@ class SeedRow:
             return self._data[name]
         raise AttributeError(f"No column '{name}' in seed data")
 
+    def __repr__(self) -> str:
+        return f"SeedRow({self._data})"
+
 
 class Seeds:
     """
-    Container for generated seed data with attribute access.
+    Container for generated seed data with attribute and dict-style access.
 
-    Allows accessing tables as attributes:
-        seeds.tb_manufacturer  # List of SeedRow objects
-        seeds.tb_model         # List of SeedRow objects
+    Access patterns:
+        seeds.tb_manufacturer       # Attribute access
+        seeds["tb_manufacturer"]    # Dict-style access
+        "tb_manufacturer" in seeds  # Membership test
+        seeds.tables()              # List of table names
+        len(seeds)                  # Number of tables
+        for name in seeds: ...      # Iterate table names
+        for name, rows in seeds.items(): ...  # Iterate pairs
     """
 
     def __init__(self):
@@ -249,6 +259,37 @@ class Seeds:
         if name in self._tables:
             return self._tables[name]
         raise AttributeError(f"No table '{name}' in seeds")
+
+    def __getitem__(self, name: str) -> list[SeedRow]:
+        """Dict-style access: seeds["tb_manufacturer"]."""
+        if name in self._tables:
+            return self._tables[name]
+        available = ", ".join(self._tables)
+        raise KeyError(f"Table '{name}' not in seeds. Available: {available}")
+
+    def __len__(self) -> int:
+        """Number of tables in seeds."""
+        return len(self._tables)
+
+    def __iter__(self):
+        """Iterate over table names."""
+        return iter(self._tables)
+
+    def __contains__(self, name: object) -> bool:
+        """Membership test: 'tb_foo' in seeds."""
+        return name in self._tables
+
+    def tables(self) -> list[str]:
+        """Return list of table names."""
+        return list(self._tables)
+
+    def items(self):
+        """Iterate over (table_name, rows) pairs."""
+        return self._tables.items()
+
+    def __repr__(self) -> str:
+        parts = [f"{name}({len(rows)})" for name, rows in self._tables.items()]
+        return f"Seeds({', '.join(parts)})"
 
     @classmethod
     def from_json(cls, file_path: Any | None = None, json_str: str | None = None) -> Seeds:
@@ -458,3 +499,18 @@ class SeedPlan:
     strategy: str = "faker"
     overrides: dict[str, Any] = field(default_factory=dict)
     groups: list[ColumnGroup] | None = field(default=None)
+
+
+@dataclass
+class ValidationResult:
+    """Result of seed plan validation.
+
+    Attributes:
+        is_valid: Whether the plan passed all checks
+        errors: List of error descriptions (empty if valid)
+        plan_summary: Ordered list of tables with counts and strategies
+    """
+
+    is_valid: bool
+    errors: list[str]
+    plan_summary: list[dict[str, Any]]

--- a/packages/fraiseql-data/tests/test_cross_schema_fk.py
+++ b/packages/fraiseql-data/tests/test_cross_schema_fk.py
@@ -1,0 +1,162 @@
+"""Tests for cross-schema foreign key support (Issue #17)."""
+
+import pytest
+from fraiseql_data import SeedBuilder
+from fraiseql_data.introspection import SchemaIntrospector
+from fraiseql_data.models import ColumnInfo, ForeignKeyInfo, TableInfo
+from psycopg import Connection
+
+
+@pytest.fixture
+def cross_schema(db_conn: Connection):
+    """Create two schemas with a cross-schema FK relationship."""
+    with db_conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS schema_parent CASCADE")
+        cur.execute("DROP SCHEMA IF EXISTS schema_child CASCADE")
+        cur.execute("CREATE SCHEMA schema_parent")
+        cur.execute("CREATE SCHEMA schema_child")
+
+        cur.execute("""
+            CREATE TABLE schema_parent.tb_organization (
+                pk_organization INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                name TEXT NOT NULL
+            )
+        """)
+        cur.execute("""
+            INSERT INTO schema_parent.tb_organization (name)
+            VALUES ('Org A'), ('Org B'), ('Org C')
+        """)
+
+        cur.execute("""
+            CREATE TABLE schema_child.tb_project (
+                pk_project INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                name TEXT NOT NULL,
+                fk_organization INTEGER NOT NULL
+                    REFERENCES schema_parent.tb_organization(pk_organization)
+            )
+        """)
+        db_conn.commit()
+
+    yield {"parent_schema": "schema_parent", "child_schema": "schema_child"}
+
+    with db_conn.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS schema_child CASCADE")
+        cur.execute("DROP SCHEMA IF EXISTS schema_parent CASCADE")
+        db_conn.commit()
+
+
+class TestCrossSchemaFKDetection:
+    """SchemaIntrospector detects cross-schema foreign keys."""
+
+    def test_fk_has_referenced_schema(self, db_conn: Connection, cross_schema):
+        introspector = SchemaIntrospector(db_conn, schema=cross_schema["child_schema"])
+        fks = introspector.get_foreign_keys("tb_project")
+
+        assert len(fks) == 1
+        fk = fks[0]
+        assert fk.column == "fk_organization"
+        assert fk.referenced_table == "tb_organization"
+        assert fk.referenced_column == "pk_organization"
+        assert fk.referenced_schema == "schema_parent"
+        assert fk.is_self_referencing is False
+
+    def test_same_schema_fk_has_no_referenced_schema(self, db_conn: Connection, cross_schema):
+        """Same-schema FKs should have referenced_schema=None."""
+        # Add a same-schema FK to test
+        with db_conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE schema_child.tb_task (
+                    pk_task INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    fk_project INTEGER NOT NULL
+                        REFERENCES schema_child.tb_project(pk_project)
+                )
+            """)
+            db_conn.commit()
+
+        introspector = SchemaIntrospector(db_conn, schema=cross_schema["child_schema"])
+        fks = introspector.get_foreign_keys("tb_task")
+
+        assert len(fks) == 1
+        assert fks[0].referenced_schema is None
+
+
+class TestCrossSchemaDepGraph:
+    """Dependency graph handles cross-schema FKs correctly."""
+
+    def test_cross_schema_target_not_in_graph(self, db_conn: Connection, cross_schema):
+        introspector = SchemaIntrospector(db_conn, schema=cross_schema["child_schema"])
+        graph = introspector.get_dependency_graph()
+
+        deps = graph.get_dependencies("tb_project")
+        # Cross-schema dependency should NOT appear as a graph node
+        assert "tb_organization" not in deps
+
+    def test_cross_schema_registered_as_external(self, db_conn: Connection, cross_schema):
+        introspector = SchemaIntrospector(db_conn, schema=cross_schema["child_schema"])
+        graph = introspector.get_dependency_graph()
+
+        assert "schema_parent.tb_organization" in graph._external_deps.get("tb_project", set())
+
+
+class TestCrossSchemaBuilder:
+    """SeedBuilder resolves cross-schema FK values from the database."""
+
+    def test_generates_rows_with_cross_schema_fk(self, db_conn: Connection, cross_schema):
+        builder = SeedBuilder(db_conn, schema=cross_schema["child_schema"])
+        builder.add("tb_project", count=5)
+        seeds = builder.execute()
+
+        rows = seeds.tb_project
+        assert len(rows) == 5
+
+        # All FK values should be valid parent PKs (1, 2, or 3)
+        for row in rows:
+            assert row.fk_organization in (1, 2, 3)
+
+    def test_staging_backend_raises_for_cross_schema_fk(self):
+        """Staging backend cannot resolve cross-schema FKs without a DB connection."""
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        table_info = TableInfo(
+            name="tb_child",
+            columns=[
+                ColumnInfo(
+                    name="pk_child",
+                    pg_type="integer",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_identity=True,
+                ),
+                ColumnInfo(name="name", pg_type="text", is_nullable=False),
+                ColumnInfo(name="fk_parent", pg_type="integer", is_nullable=False),
+            ],
+            foreign_keys=[
+                ForeignKeyInfo(
+                    column="fk_parent",
+                    referenced_table="tb_parent",
+                    referenced_column="pk_parent",
+                    referenced_schema="other_schema",
+                ),
+            ],
+        )
+        builder.set_table_schema("tb_child", table_info)
+        builder.add("tb_child", count=1)
+
+        with pytest.raises(Exception, match="cross-schema"):
+            builder.execute()
+
+
+class TestCrossSchemaAutoDeps:
+    """Auto-deps skips cross-schema FK targets."""
+
+    def test_auto_deps_ignores_cross_schema(self, db_conn: Connection, cross_schema):
+        """Cross-schema dependencies should not appear in auto-deps tree."""
+        from fraiseql_data.auto_deps import AutoDependencyResolver
+        from fraiseql_data.seed_common import SeedCommon
+
+        introspector = SchemaIntrospector(db_conn, schema=cross_schema["child_schema"])
+        resolver = AutoDependencyResolver(introspector, SeedCommon(instance_offsets={}, data=None))
+
+        deps = resolver.build_dependency_tree("tb_project")
+        # tb_organization lives in schema_parent, should be skipped
+        assert "tb_organization" not in deps

--- a/packages/fraiseql-data/tests/test_seed_all.py
+++ b/packages/fraiseql-data/tests/test_seed_all.py
@@ -1,0 +1,197 @@
+"""Tests for SeedBuilder.seed_all() auto-discovery."""
+
+from fraiseql_data import SeedBuilder
+from fraiseql_data.models import ColumnInfo, ForeignKeyInfo, TableInfo
+
+
+def _parent_table():
+    return TableInfo(
+        name="tb_parent",
+        columns=[
+            ColumnInfo(
+                name="pk_parent",
+                pg_type="integer",
+                is_nullable=False,
+                is_primary_key=True,
+                is_identity=True,
+            ),
+            ColumnInfo(name="name", pg_type="text", is_nullable=False),
+        ],
+    )
+
+
+def _child_table():
+    return TableInfo(
+        name="tb_child",
+        columns=[
+            ColumnInfo(
+                name="pk_child",
+                pg_type="integer",
+                is_nullable=False,
+                is_primary_key=True,
+                is_identity=True,
+            ),
+            ColumnInfo(name="title", pg_type="text", is_nullable=False),
+            ColumnInfo(name="fk_parent", pg_type="integer", is_nullable=False),
+        ],
+        foreign_keys=[
+            ForeignKeyInfo(
+                column="fk_parent",
+                referenced_table="tb_parent",
+                referenced_column="pk_parent",
+            ),
+        ],
+    )
+
+
+def _standalone_table():
+    return TableInfo(
+        name="tb_standalone",
+        columns=[
+            ColumnInfo(
+                name="pk_standalone",
+                pg_type="integer",
+                is_nullable=False,
+                is_primary_key=True,
+                is_identity=True,
+            ),
+            ColumnInfo(name="value", pg_type="text", is_nullable=False),
+        ],
+    )
+
+
+class TestSeedAllBasic:
+    def test_seeds_all_tables(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+        builder.set_table_schema("tb_child", _child_table())
+
+        seeds = builder.seed_all(default_count=3)
+
+        assert "tb_parent" in seeds
+        assert "tb_child" in seeds
+        assert len(seeds["tb_parent"]) == 3
+        assert len(seeds["tb_child"]) == 3
+
+    def test_default_count(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+
+        seeds = builder.seed_all(default_count=7)
+
+        assert len(seeds["tb_parent"]) == 7
+
+
+class TestSeedAllCustomCounts:
+    def test_per_table_counts(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+        builder.set_table_schema("tb_standalone", _standalone_table())
+
+        seeds = builder.seed_all(
+            default_count=2,
+            counts={"tb_parent": 10},
+        )
+
+        assert len(seeds["tb_parent"]) == 10
+        assert len(seeds["tb_standalone"]) == 2
+
+
+class TestSeedAllOverrides:
+    def test_per_table_overrides(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+
+        seeds = builder.seed_all(
+            default_count=3,
+            overrides={"tb_parent": {"name": "Fixed Name"}},
+        )
+
+        for row in seeds["tb_parent"]:
+            assert row.name == "Fixed Name"
+
+
+class TestSeedAllExclude:
+    def test_excluded_tables_skipped(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+        builder.set_table_schema("tb_standalone", _standalone_table())
+
+        seeds = builder.seed_all(
+            default_count=3,
+            exclude={"tb_standalone"},
+        )
+
+        assert "tb_parent" in seeds
+        assert "tb_standalone" not in seeds
+
+    def test_exclude_as_list(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+        builder.set_table_schema("tb_standalone", _standalone_table())
+
+        seeds = builder.seed_all(
+            default_count=3,
+            exclude=["tb_standalone"],
+        )
+
+        assert "tb_standalone" not in seeds
+
+
+class TestSeedAllFKOrder:
+    def test_respects_fk_order(self):
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_parent", _parent_table())
+        builder.set_table_schema("tb_child", _child_table())
+
+        seeds = builder.seed_all(default_count=5)
+
+        # Child FK values should reference generated parent PKs
+        parent_pks = {row.pk_parent for row in seeds["tb_parent"]}
+        for row in seeds["tb_child"]:
+            assert row.fk_parent in parent_pks
+
+
+class TestSeedAllCrossSchemaFK:
+    def test_nullable_cross_schema_fk_empty_table(self):
+        """Cross-schema FK on nullable column with no parent rows."""
+        table = TableInfo(
+            name="tb_local",
+            columns=[
+                ColumnInfo(
+                    name="pk_local",
+                    pg_type="integer",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_identity=True,
+                ),
+                ColumnInfo(name="name", pg_type="text", is_nullable=False),
+                ColumnInfo(
+                    name="fk_external",
+                    pg_type="integer",
+                    is_nullable=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeyInfo(
+                    column="fk_external",
+                    referenced_table="tb_remote",
+                    referenced_column="pk_remote",
+                    referenced_schema="other_schema",
+                ),
+            ],
+        )
+
+        builder = SeedBuilder(None, schema="test", backend="staging")
+        builder.set_table_schema("tb_local", table)
+
+        # Cross-schema FK on staging backend with nullable column:
+        # should work if we override the FK to None
+        seeds = builder.seed_all(
+            default_count=3,
+            overrides={"tb_local": {"fk_external": None}},
+        )
+
+        assert len(seeds["tb_local"]) == 3
+        for row in seeds["tb_local"]:
+            assert row.fk_external is None

--- a/packages/fraiseql-data/tests/test_seed_common.py
+++ b/packages/fraiseql-data/tests/test_seed_common.py
@@ -533,20 +533,16 @@ baseline:
             assert instance >= 1001
 
 
-def test_seed_common_warning_fires_once_per_process(db_conn, test_schema, caplog):
-    """Warning fires at most once across multiple SeedBuilder instances."""
+def test_no_warning_when_seed_common_none(db_conn, test_schema, caplog):
+    """No warning when seed_common=None — quiet default."""
     import logging
 
-    import fraiseql_data.builder as builder_mod
     from fraiseql_data import SeedBuilder
-
-    # Reset the module-level dedup flag
-    builder_mod._seed_common_warned = False
 
     with db_conn.cursor() as cur:
         cur.execute(
             f"""
-            CREATE TABLE {test_schema}.tb_dedup_test (
+            CREATE TABLE {test_schema}.tb_quiet_default (
                 pk_id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 name TEXT NOT NULL
             )
@@ -554,74 +550,11 @@ def test_seed_common_warning_fires_once_per_process(db_conn, test_schema, caplog
         )
         db_conn.commit()
 
-    with caplog.at_level(logging.WARNING):
-        SeedBuilder(db_conn, schema=test_schema, seed_common=None)
-        caplog.clear()
-        SeedBuilder(db_conn, schema=test_schema, seed_common=None)
-
-    # Second instance should NOT have logged the warning
-    assert "No seed common defined" not in caplog.text
-
-
-def test_no_warning_when_validate_seed_common_false(db_conn, test_schema, caplog):
-    """No warning when user explicitly passes validate_seed_common=False."""
-    import logging
-
-    from fraiseql_data import SeedBuilder
-
-    with db_conn.cursor() as cur:
-        cur.execute(
-            f"""
-            CREATE TABLE {test_schema}.tb_warning_opt_out (
-                pk_id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-                name TEXT NOT NULL
-            )
-        """
-        )
-        db_conn.commit()
-
-    with caplog.at_level(logging.WARNING):
-        SeedBuilder(
-            db_conn,
-            schema=test_schema,
-            seed_common=None,
-            validate_seed_common=False,
-        )
-
-    assert "No seed common defined" not in caplog.text
-
-
-def test_builder_without_seed_common_warning(db_conn, test_schema, caplog):
-    """Warn when seed_common=None."""
-    import logging
-
-    import fraiseql_data.builder as builder_mod
-    from fraiseql_data import SeedBuilder
-
-    builder_mod._seed_common_warned = False
-
-    # Create schema
-    with db_conn.cursor() as cur:
-        cur.execute(
-            f"""
-            CREATE TABLE {test_schema}.tb_organization (
-                pk_organization INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-                id UUID NOT NULL UNIQUE,
-                identifier TEXT NOT NULL UNIQUE,
-                name TEXT NOT NULL
-            )
-        """
-        )
-        db_conn.commit()
-
-    # Capture logs
     with caplog.at_level(logging.WARNING):
         builder = SeedBuilder(db_conn, schema=test_schema, seed_common=None)
 
-    # Should have logged warning about missing seed common
     assert builder is not None
-    assert "No seed common defined" in caplog.text
-    assert "UUID collisions may occur" in caplog.text
+    assert "No seed common defined" not in caplog.text
 
 
 def test_trinity_pattern_after_seed_common(db_conn, test_schema):

--- a/packages/fraiseql-data/tests/test_seeds_api.py
+++ b/packages/fraiseql-data/tests/test_seeds_api.py
@@ -1,0 +1,92 @@
+"""Tests for Seeds and SeedRow discoverable API."""
+
+import pytest
+from fraiseql_data.models import SeedRow, Seeds
+
+
+@pytest.fixture
+def seeds():
+    """Create a Seeds object with two tables."""
+    s = Seeds()
+    s.add_table("tb_org", [{"pk": 1, "name": "Org A"}, {"pk": 2, "name": "Org B"}])
+    s.add_table("tb_user", [{"pk": 10, "name": "Alice"}])
+    return s
+
+
+class TestSeedsGetitem:
+    def test_existing_table(self, seeds):
+        rows = seeds["tb_org"]
+        assert len(rows) == 2
+        assert rows[0].pk == 1
+
+    def test_missing_table_raises_keyerror(self, seeds):
+        with pytest.raises(KeyError, match="tb_missing"):
+            seeds["tb_missing"]
+
+
+class TestSeedsLen:
+    def test_counts_tables(self, seeds):
+        assert len(seeds) == 2
+
+    def test_empty_seeds(self):
+        assert len(Seeds()) == 0
+
+
+class TestSeedsIter:
+    def test_yields_table_names(self, seeds):
+        names = list(seeds)
+        assert "tb_org" in names
+        assert "tb_user" in names
+        assert len(names) == 2
+
+
+class TestSeedsContains:
+    def test_existing_table(self, seeds):
+        assert "tb_org" in seeds
+
+    def test_missing_table(self, seeds):
+        assert "tb_missing" not in seeds
+
+
+class TestSeedsTables:
+    def test_returns_list(self, seeds):
+        tables = seeds.tables()
+        assert isinstance(tables, list)
+        assert set(tables) == {"tb_org", "tb_user"}
+
+
+class TestSeedsItems:
+    def test_yields_pairs(self, seeds):
+        pairs = dict(seeds.items())
+        assert "tb_org" in pairs
+        assert len(pairs["tb_org"]) == 2
+        assert len(pairs["tb_user"]) == 1
+
+
+class TestSeedsRepr:
+    def test_repr(self, seeds):
+        r = repr(seeds)
+        assert "Seeds(" in r
+        assert "tb_org(2)" in r
+        assert "tb_user(1)" in r
+
+    def test_empty_repr(self):
+        assert repr(Seeds()) == "Seeds()"
+
+
+class TestSeedsGetattr:
+    def test_backward_compat(self, seeds):
+        rows = seeds.tb_org
+        assert len(rows) == 2
+
+    def test_missing_raises_attributeerror(self, seeds):
+        with pytest.raises(AttributeError, match="tb_missing"):
+            seeds.tb_missing  # noqa: B018
+
+
+class TestSeedRowRepr:
+    def test_repr(self):
+        row = SeedRow(_data={"pk": 1, "name": "Alice"})
+        r = repr(row)
+        assert "SeedRow(" in r
+        assert "'pk': 1" in r

--- a/packages/fraiseql-data/tests/test_type_generators.py
+++ b/packages/fraiseql-data/tests/test_type_generators.py
@@ -194,6 +194,61 @@ class TestNumericPrecision:
             )
 
 
+class TestShortVarcharHeuristics:
+    """Column-name heuristics for common short-varchar patterns."""
+
+    def test_lang_generates_iso_code(self):
+        gen = FakerGenerator()
+        for _ in range(20):
+            value = gen.generate("lang", "character varying", max_length=2)
+            assert len(value) == 2
+
+    def test_language_generates_iso_code(self):
+        gen = FakerGenerator()
+        value = gen.generate("language", "character varying")
+        assert len(value) == 2
+
+    def test_locale_generates_posix_locale(self):
+        gen = FakerGenerator()
+        for _ in range(20):
+            value = gen.generate("locale", "character varying", max_length=10)
+            assert "_" in value
+            assert len(value) <= 10
+
+    def test_domain_tld_generates_tld(self):
+        gen = FakerGenerator()
+        value = gen.generate("domain_tld", "character varying", max_length=10)
+        assert value.startswith(".")
+        assert len(value) <= 10
+
+    def test_tld_generates_tld(self):
+        gen = FakerGenerator()
+        value = gen.generate("tld", "varchar")
+        assert value.startswith(".")
+
+    def test_mobile_phone_suffix_match(self):
+        gen = FakerGenerator()
+        value = gen.generate("mobile_phone", "character varying")
+        assert isinstance(value, str)
+        assert len(value) > 0
+
+    def test_office_phone_suffix_match(self):
+        gen = FakerGenerator()
+        value = gen.generate("office_phone", "character varying")
+        assert isinstance(value, str)
+
+    def test_contact_email_suffix_match(self):
+        gen = FakerGenerator()
+        value = gen.generate("contact_email", "character varying")
+        assert isinstance(value, str)
+        assert "@" in value
+
+    def test_exact_phone_still_works(self):
+        gen = FakerGenerator()
+        value = gen.generate("phone", "text")
+        assert isinstance(value, str)
+
+
 class TestIntrospectorNumericType:
     """Introspector resolves numeric(p,s) from precision/scale columns."""
 
@@ -239,6 +294,125 @@ class TestUnknownTypeWarning:
             gen.generate("col", "integer")
 
         assert not any("integer" in r.message for r in caplog.records)
+
+
+class TestVarcharLengthConstraints:
+    """Varchar length constraints are respected."""
+
+    def test_max_length_truncates_text(self):
+        gen = FakerGenerator()
+        for _ in range(50):
+            value = gen.generate("description", "character varying", max_length=10)
+            assert isinstance(value, str)
+            assert len(value) <= 10
+
+    def test_short_varchar_2(self):
+        gen = FakerGenerator()
+        for _ in range(50):
+            value = gen.generate("lang", "character varying", max_length=2)
+            assert len(value) <= 2
+
+    def test_no_max_length_no_truncation(self):
+        gen = FakerGenerator()
+        value = gen.generate("description", "character varying")
+        assert isinstance(value, str)
+
+    def test_max_length_on_column_name_mapping(self):
+        gen = FakerGenerator()
+        for _ in range(50):
+            value = gen.generate("email", "character varying", max_length=15)
+            assert len(value) <= 15
+
+    def test_max_length_does_not_affect_non_string(self):
+        gen = FakerGenerator()
+        value = gen.generate("count", "integer", max_length=5)
+        assert isinstance(value, int)
+
+
+class TestUserDefinedTypes:
+    """USER-DEFINED types generate valid values."""
+
+    def test_ltree_generates_dotted_path(self):
+        gen = FakerGenerator()
+        value = gen.generate("path", "ltree")
+        assert isinstance(value, str)
+        assert "." in value
+
+    def test_citext_generates_text(self):
+        gen = FakerGenerator()
+        value = gen.generate("label", "citext")
+        assert isinstance(value, str)
+        assert len(value) > 0
+
+    def test_hstore_generates_keyvalue(self):
+        gen = FakerGenerator()
+        value = gen.generate("metadata", "hstore")
+        assert isinstance(value, str)
+        assert "=>" in value
+
+    def test_custom_udt_registry(self):
+        FakerGenerator.register_udt_generator("my_custom_type", lambda: "custom_value")
+        gen = FakerGenerator()
+        assert gen.generate("col", "my_custom_type") == "custom_value"
+        # Cleanup
+        del FakerGenerator._custom_udt_generators["my_custom_type"]
+
+    def test_custom_udt_overrides_fallback(self):
+        FakerGenerator.register_udt_generator("exotic_type", lambda: 42)
+        gen = FakerGenerator()
+        assert gen.generate("col", "exotic_type") == 42
+        del FakerGenerator._custom_udt_generators["exotic_type"]
+
+    def test_resolve_pg_type_user_defined_returns_udt_name(self):
+        from fraiseql_data.introspection import SchemaIntrospector
+
+        assert SchemaIntrospector._resolve_pg_type("USER-DEFINED", "ltree") == "ltree"
+        assert SchemaIntrospector._resolve_pg_type("USER-DEFINED", "citext") == "citext"
+        assert SchemaIntrospector._resolve_pg_type("USER-DEFINED", "hstore") == "hstore"
+
+
+class TestSoftDeleteColumns:
+    """Soft-delete columns default to None when nullable."""
+
+    def test_deleted_at_nullable_returns_none(self):
+        gen = FakerGenerator()
+        value = gen.generate("deleted_at", "timestamp with time zone", is_nullable=True)
+        assert value is None
+
+    def test_deleted_at_not_nullable_generates_value(self):
+        gen = FakerGenerator()
+        value = gen.generate("deleted_at", "timestamp with time zone", is_nullable=False)
+        assert value is not None
+
+    def test_soft_deleted_at_nullable_returns_none(self):
+        gen = FakerGenerator()
+        value = gen.generate("soft_deleted_at", "timestamptz", is_nullable=True)
+        assert value is None
+
+    def test_removed_at_nullable_returns_none(self):
+        gen = FakerGenerator()
+        value = gen.generate("removed_at", "timestamp without time zone", is_nullable=True)
+        assert value is None
+
+    def test_archived_at_nullable_returns_none(self):
+        gen = FakerGenerator()
+        value = gen.generate("archived_at", "timestamptz", is_nullable=True)
+        assert value is None
+
+    def test_custom_suffix_deleted_at(self):
+        gen = FakerGenerator()
+        value = gen.generate("user_deleted_at", "timestamptz", is_nullable=True)
+        assert value is None
+
+    def test_created_at_not_affected(self):
+        gen = FakerGenerator()
+        value = gen.generate("created_at", "timestamptz", is_nullable=True)
+        assert value is not None
+
+    def test_updated_at_not_affected(self):
+        gen = FakerGenerator()
+        value = gen.generate("updated_at", "timestamp with time zone", is_nullable=True)
+        assert value is not None
 
 
 class TestIdentityAndSerialSkip:

--- a/packages/fraiseql-data/tests/test_validation.py
+++ b/packages/fraiseql-data/tests/test_validation.py
@@ -1,0 +1,139 @@
+"""Tests for SeedBuilder.validate() pre-execution validation."""
+
+from fraiseql_data import SeedBuilder, ValidationResult
+from fraiseql_data.models import ColumnInfo, ForeignKeyInfo, TableInfo
+
+
+def _make_builder_with_tables(*table_infos: TableInfo) -> SeedBuilder:
+    """Create a staging builder with pre-registered table schemas."""
+    builder = SeedBuilder(None, schema="test", backend="staging")
+    for t in table_infos:
+        builder.set_table_schema(t.name, t)
+    return builder
+
+
+PARENT = TableInfo(
+    name="tb_parent",
+    columns=[
+        ColumnInfo(
+            name="pk_parent",
+            pg_type="integer",
+            is_nullable=False,
+            is_primary_key=True,
+            is_identity=True,
+        ),
+        ColumnInfo(name="name", pg_type="text", is_nullable=False),
+    ],
+)
+
+CHILD = TableInfo(
+    name="tb_child",
+    columns=[
+        ColumnInfo(
+            name="pk_child",
+            pg_type="integer",
+            is_nullable=False,
+            is_primary_key=True,
+            is_identity=True,
+        ),
+        ColumnInfo(name="name", pg_type="text", is_nullable=False),
+        ColumnInfo(name="fk_parent", pg_type="integer", is_nullable=False),
+    ],
+    foreign_keys=[
+        ForeignKeyInfo(
+            column="fk_parent",
+            referenced_table="tb_parent",
+            referenced_column="pk_parent",
+        ),
+    ],
+)
+
+
+class TestValidateValidPlan:
+    def test_valid_plan_returns_is_valid(self):
+        builder = _make_builder_with_tables(PARENT, CHILD)
+        builder.add("tb_parent", count=5)
+        builder.add("tb_child", count=10)
+
+        result = builder.validate()
+
+        assert isinstance(result, ValidationResult)
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_plan_summary_has_all_tables(self):
+        builder = _make_builder_with_tables(PARENT, CHILD)
+        builder.add("tb_parent", count=5)
+        builder.add("tb_child", count=10)
+
+        result = builder.validate()
+
+        tables_in_summary = [s["table"] for s in result.plan_summary]
+        assert "tb_parent" in tables_in_summary
+        assert "tb_child" in tables_in_summary
+
+    def test_plan_summary_sorted_by_deps(self):
+        builder = _make_builder_with_tables(PARENT, CHILD)
+        # Add child before parent — summary should still be sorted
+        builder.add("tb_child", count=10)
+        builder.add("tb_parent", count=5)
+
+        result = builder.validate()
+
+        tables_in_summary = [s["table"] for s in result.plan_summary]
+        assert tables_in_summary.index("tb_parent") < tables_in_summary.index("tb_child")
+
+    def test_plan_summary_includes_count_and_strategy(self):
+        builder = _make_builder_with_tables(PARENT)
+        builder.add("tb_parent", count=7)
+
+        result = builder.validate()
+
+        assert result.plan_summary[0] == {
+            "table": "tb_parent",
+            "count": 7,
+            "strategy": "faker",
+        }
+
+
+class TestValidateMissingDependency:
+    def test_missing_dep_returns_error(self):
+        builder = _make_builder_with_tables(PARENT, CHILD)
+        # Add child without parent
+        builder.add("tb_child", count=10)
+
+        result = builder.validate()
+
+        assert result.is_valid is False
+        assert len(result.errors) == 1
+        assert "tb_parent" in result.errors[0]
+
+    def test_overridden_fk_passes_validation(self):
+        builder = _make_builder_with_tables(PARENT, CHILD)
+        builder.add("tb_child", count=10, overrides={"fk_parent": 1})
+
+        result = builder.validate()
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+
+class TestValidateEmptyPlan:
+    def test_empty_plan_is_valid(self):
+        builder = _make_builder_with_tables(PARENT)
+        result = builder.validate()
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert result.plan_summary == []
+
+
+class TestValidateSingleTable:
+    def test_single_table_no_deps(self):
+        builder = _make_builder_with_tables(PARENT)
+        builder.add("tb_parent", count=3)
+
+        result = builder.validate()
+
+        assert result.is_valid is True
+        assert len(result.plan_summary) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "fraiseql-seed"
-version = "0.1.3"
+version = "0.1.4"
 description = "FraiseQL Seed - UUID patterns and data generation for PostgreSQL"
 authors = [
     {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-data"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "packages/fraiseql-data" }
 dependencies = [
     { name = "faker" },
@@ -333,7 +333,7 @@ provides-extras = ["dev", "cli", "confiture"]
 
 [[package]]
 name = "fraiseql-seed"
-version = "0.1.2"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "fraiseql-data" },
@@ -382,7 +382,7 @@ docs = [
 
 [[package]]
 name = "fraiseql-uuid"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/fraiseql-uuid" }
 dependencies = [
     { name = "pydantic" },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.3",
-  "commit": "9cbacf2",
+  "version": "0.1.4",
+  "commit": "35469ea",
   "branch": "feat/generator-context-enrichment",
-  "timestamp": "2026-03-21T16:39:56Z"
+  "timestamp": "2026-05-27T09:45:00Z"
 }


### PR DESCRIPTION
## Summary

Final step of the release chain. Merging this PR triggers `deploy.yml` in
production mode: build → PyPI publish → GitHub Release tagged `v0.1.4`.

This is the last release that will go through the `version.json` gating
mechanism. The follow-up release-please migration PR will retire it.

## What ships
- `fraiseql-data 0.1.4` → new release on PyPI
- `fraiseql-uuid 0.1.3` → no-op (already on PyPI, `skip-existing` handles it)
- GitHub release `v0.1.4` with both packages' artifacts

## Verification chain so far
- PR #25 (feat → dev): ✅ quality-gate green, ✅ deploy.yml build-only green
- PR #26 (dev → staging): ✅ quality-gate green, ✅ deploy.yml build-only green
- This PR (staging → main): final publish gate

## Test plan
- [ ] After merge: `deploy.yml` `check-version` detects 0.1.3 → 0.1.4 and sets `should_deploy=true`.
- [ ] Build job produces both wheel/sdist artifacts.
- [ ] Publish job runs (production env) and uploads `fraiseql-data-0.1.4` to PyPI via OIDC trusted publisher.
- [ ] `fraiseql-uuid-0.1.3` publish step exits clean via `skip-existing`.
- [ ] GitHub Release `v0.1.4` is created with both packages' artifacts attached.
- [ ] PyPI shows `fraiseql-data 0.1.4` as latest within ~1 minute.

## Follow-up
Once 0.1.4 is on PyPI, the release-please migration PR can be cut against `main`. See `/tmp/release-please-migration/PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)