### PR TITLE
chore: migrate release pipeline to release-please (resolves #24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,96 +1,64 @@
 name: Deploy & Publish
 
-# Branch-triggered deployment pipeline:
-#   dev     → build + test only (no publish)
-#   staging → build + test only (no publish)
-#   main    → build + test + publish to PyPI + GitHub Release
+# Triggered by release-please tagging a per-package release.
+# Tag scheme: fraiseql-<pkg>-v<X.Y.Z> (e.g. fraiseql-uuid-v0.1.4)
+#
+# This workflow filename and the `pypi` environment name MUST stay as-is —
+# the PyPI trusted publisher is pinned to them.
+
 on:
-  push:
-    branches: [dev, staging, main]
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Target environment'
-        required: true
-        type: choice
-        options:
-          - development
-          - staging
-          - production
+  release:
+    types: [published]
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
 
 permissions:
-  contents: write   # GitHub Release creation
+  contents: write   # upload artifacts to the GitHub Release
   id-token: write   # PyPI trusted publishing (OIDC)
 
 jobs:
-  # ------------------------------------------------------------------
-  # 1. Check whether a deploy is needed (version bump detection)
-  # ------------------------------------------------------------------
-  check-version:
-    name: Check Version
+  parse-tag:
+    name: Parse release tag
     runs-on: ubuntu-latest
     outputs:
-      should_deploy: ${{ steps.check.outputs.should_deploy }}
-      version: ${{ steps.check.outputs.version }}
-      previous_version: ${{ steps.check.outputs.previous_version }}
-      environment: ${{ steps.env.outputs.environment }}
+      package: ${{ steps.parse.outputs.package }}
+      package_dir: ${{ steps.parse.outputs.package_dir }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - id: parse
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          case "$TAG" in
+            fraiseql-uuid-v*)
+              PACKAGE=fraiseql-uuid
+              DIR=packages/fraiseql-uuid
+              VERSION="${TAG#fraiseql-uuid-v}"
+              ;;
+            fraiseql-data-v*)
+              PACKAGE=fraiseql-data
+              DIR=packages/fraiseql-data
+              VERSION="${TAG#fraiseql-data-v}"
+              ;;
+            *)
+              echo "::error::Tag $TAG does not match any known package pattern; skipping"
+              exit 1
+              ;;
+          esac
+          echo "package=$PACKAGE"     >> "$GITHUB_OUTPUT"
+          echo "package_dir=$DIR"     >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION"     >> "$GITHUB_OUTPUT"
+          echo "Releasing $PACKAGE $VERSION from $DIR"
+
+  build:
+    name: Build ${{ needs.parse-tag.outputs.package }}
+    runs-on: ubuntu-latest
+    needs: parse-tag
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # Need HEAD and HEAD~1 for diff
-
-      - name: Detect environment
-        id: env
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
-          else
-            case "${{ github.ref_name }}" in
-              dev)     echo "environment=development" >> $GITHUB_OUTPUT ;;
-              staging) echo "environment=staging"     >> $GITHUB_OUTPUT ;;
-              main)    echo "environment=production"  >> $GITHUB_OUTPUT ;;
-              *)       echo "environment=unknown"     >> $GITHUB_OUTPUT ;;
-            esac
-          fi
-
-      - name: Check for version change
-        id: check
-        run: |
-          CURRENT=$(jq -r .version version.json)
-          PREVIOUS=$(git show HEAD~1:version.json 2>/dev/null | jq -r .version 2>/dev/null || echo "none")
-
-          echo "version=$CURRENT" >> $GITHUB_OUTPUT
-          echo "previous_version=$PREVIOUS" >> $GITHUB_OUTPUT
-
-          # Always deploy on workflow_dispatch or staging push
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "Deploy reason: manual trigger"
-          elif [ "${{ github.ref_name }}" = "staging" ]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "Deploy reason: staging push"
-          elif [ "$CURRENT" != "$PREVIOUS" ]; then
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "Deploy reason: version bumped $PREVIOUS → $CURRENT"
-          else
-            echo "should_deploy=false" >> $GITHUB_OUTPUT
-            echo "No version change ($CURRENT) — skipping deploy"
-          fi
-
-  # ------------------------------------------------------------------
-  # 2. Build both packages
-  # ------------------------------------------------------------------
-  build:
-    name: Build Packages
-    runs-on: ubuntu-latest
-    needs: check-version
-    if: needs.check-version.outputs.should_deploy == 'true'
-    steps:
-      - uses: actions/checkout@v4
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -100,121 +68,61 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run quality checks
+      - name: Verify pyproject.toml version matches tag
         run: |
-          uv run ruff check
-          uv run ruff format --check
-          uv run ty check
+          PY_VERSION=$(python -c "
+          import tomllib, sys, pathlib
+          p = pathlib.Path('${{ needs.parse-tag.outputs.package_dir }}/pyproject.toml')
+          print(tomllib.loads(p.read_text())['project']['version'])
+          ")
+          TAG_VERSION="${{ needs.parse-tag.outputs.version }}"
+          if [ "$PY_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version $TAG_VERSION != pyproject.toml $PY_VERSION"
+            exit 1
+          fi
+          echo "✅ pyproject.toml version $PY_VERSION matches tag $TAG_VERSION"
 
-      - name: Build fraiseql-uuid
-        run: |
-          uv build --package fraiseql-uuid --out-dir dist-uuid/
-          ls -la dist-uuid/
+      - name: Build sdist and wheel
+        run: uv build --package "${{ needs.parse-tag.outputs.package }}" --out-dir dist/
 
-      - name: Build fraiseql-data
-        run: |
-          uv build --package fraiseql-data --out-dir dist-data/
-          ls -la dist-data/
-
-      - name: Upload fraiseql-uuid dist
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-fraiseql-uuid
-          path: dist-uuid/
+          name: dist-${{ needs.parse-tag.outputs.package }}
+          path: dist/
 
-      - name: Upload fraiseql-data dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-fraiseql-data
-          path: dist-data/
-
-  # ------------------------------------------------------------------
-  # 3. Publish (environment-dependent)
-  # ------------------------------------------------------------------
   publish:
-    name: Publish to PyPI
+    name: Publish ${{ needs.parse-tag.outputs.package }} to PyPI
     runs-on: ubuntu-latest
-    needs: [check-version, build]
-    if: needs.check-version.outputs.environment == 'production'
+    needs: [parse-tag, build]
     environment:
       name: pypi
-      url: https://pypi.org/project/fraiseql-data/
+      url: https://pypi.org/project/${{ needs.parse-tag.outputs.package }}/${{ needs.parse-tag.outputs.version }}/
     steps:
-      - name: Download fraiseql-uuid dist
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist-fraiseql-uuid
-          path: dist-uuid/
+          name: dist-${{ needs.parse-tag.outputs.package }}
+          path: dist/
 
-      - name: Download fraiseql-data dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist-fraiseql-data
-          path: dist-data/
-
-      - name: Publish fraiseql-uuid to PyPI
+      - name: Publish to PyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist-uuid/
+          packages-dir: dist/
           skip-existing: true
 
-      - name: Publish fraiseql-data to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist-data/
-          skip-existing: true
-
-  # ------------------------------------------------------------------
-  # 4. GitHub Release (production only)
-  # ------------------------------------------------------------------
-  release:
-    name: GitHub Release
+  attach-artifacts:
+    name: Attach artifacts to GitHub Release
     runs-on: ubuntu-latest
-    needs: [check-version, build, publish]
-    if: needs.check-version.outputs.environment == 'production'
+    needs: [parse-tag, publish]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all dist artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          path: all-dist/
+          name: dist-${{ needs.parse-tag.outputs.package }}
+          path: dist/
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.check-version.outputs.version }}
-          name: v${{ needs.check-version.outputs.version }}
-          generate_release_notes: true
-          files: |
-            all-dist/dist-fraiseql-uuid/*
-            all-dist/dist-fraiseql-data/*
+      - name: Upload to release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # ------------------------------------------------------------------
-  # 5. Notify
-  # ------------------------------------------------------------------
-  notify:
-    name: Deploy Summary
-    runs-on: ubuntu-latest
-    needs: [check-version, build, publish, release]
-    if: always()
-    steps:
-      - name: Summary
-        run: |
-          ENV="${{ needs.check-version.outputs.environment }}"
-          VER="${{ needs.check-version.outputs.version }}"
-
-          echo "## Deploy Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Environment | $ENV |" >> $GITHUB_STEP_SUMMARY
-          echo "| Version | $VER |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Publish | ${{ needs.publish.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Release | ${{ needs.release.result }} |" >> $GITHUB_STEP_SUMMARY
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,11 +1,11 @@
 name: Quality Gate
 
-# Comprehensive quality checks for all PR and main branch protection
+# Comprehensive quality checks for all PRs and main branch protection
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   push:
-    branches: [main, dev]
+    branches: [main]
 
 concurrency:
   group: quality-gate-${{ github.ref }}
@@ -253,9 +253,10 @@ jobs:
           }
         echo "✅ All markdown files are properly formatted"
 
-  # Quality gate summary job - this job fails if any quality check fails
+  # Quality gate summary job - this job fails if any quality check fails.
+  # Job ID intentionally matches the branch-protection required context name
+  # (drop the `name:` field so the check_run is reported as "quality-gate").
   quality-gate:
-    name: Quality Gate ✅
     runs-on: ubuntu-latest
     needs: [unit-tests, postgres-tests, lint, type-check, markdown-quality]
     if: always()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,33 @@
+name: release-please
+
+# Maintains per-package release PRs based on Conventional Commits.
+# When a release PR is merged, tags + a GitHub Release are created
+# (e.g. fraiseql-uuid-v0.1.4), which triggers deploy.yml to publish to PyPI.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write       # create tags, releases, commit manifest updates
+  pull-requests: write  # open/update release PRs
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          # MUST be a PAT or GitHub App token, NOT the default GITHUB_TOKEN.
+          # GitHub deliberately does not trigger workflows from events created
+          # by GITHUB_TOKEN — using it here would mean release-please's PRs
+          # silently skip quality-gate.yml. The fine-grained PAT stored in
+          # RELEASE_PLEASE_TOKEN runs as a human user, so its PRs do trigger
+          # the full quality-gate suite.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -3,9 +3,9 @@ name: Security & Compliance
 # Comprehensive security and compliance checks
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   schedule:
     # Run weekly security scans
     - cron: '0 2 * * 1'  # Every Monday at 2 AM UTC
@@ -356,8 +356,10 @@ jobs:
           echo "✅ No obvious hardcoded secrets found"
         fi
 
+  # Security gate summary job. Job ID intentionally matches the
+  # branch-protection required context name — no `name:` field so the
+  # check_run is reported as "security-gate".
   security-gate:
-    name: Security Gate ✅
     runs-on: ubuntu-latest
     needs: [secrets-scan, license-scan, dependency-audit, trivy-scan, compliance-check]
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test All Packages
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   test:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  "packages/fraiseql-uuid": "0.1.3",
+  "packages/fraiseql-data": "0.1.4"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,9 @@
-# fraiseql-seed - Monorepo Root Configuration
-# This is a workspace root that coordinates multiple packages
+# fraiseql-seed - Monorepo workspace root.
+#
+# Intentionally has no [project] table — this is a uv workspace marker,
+# not a publishable package. Per-package metadata and versions live in
+# packages/*/pyproject.toml and are managed by release-please.
 
-[project]
-name = "fraiseql-seed"
-version = "0.1.4"
-description = "FraiseQL Seed - UUID patterns and data generation for PostgreSQL"
-authors = [
-    {name = "Lionel Hamayon", email = "lionel.hamayon@evolution-digitale.fr"}
-]
-readme = "README.md"
-license = {text = "MIT"}
-requires-python = ">=3.11"
-
-# Include workspace packages for development
-dependencies = [
-    "fraiseql-uuid",
-    "fraiseql-data",
-]
-
-# This is a workspace root, not a publishable package
 [tool.uv]
 managed = true
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "python",
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
+  "draft": false,
+  "prerelease": false,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance"},
+    {"type": "refactor", "section": "Refactors"},
+    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "chore", "section": "Chores", "hidden": true},
+    {"type": "ci", "section": "CI", "hidden": true},
+    {"type": "build", "section": "Build", "hidden": true}
+  ],
+  "packages": {
+    "packages/fraiseql-uuid": {
+      "package-name": "fraiseql-uuid",
+      "component": "fraiseql-uuid"
+    },
+    "packages/fraiseql-data": {
+      "package-name": "fraiseql-data",
+      "component": "fraiseql-data"
+    }
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -5,8 +5,24 @@ requires-python = ">=3.11"
 [manifest]
 members = [
     "fraiseql-data",
-    "fraiseql-seed",
     "fraiseql-uuid",
+]
+
+[manifest.dependency-groups]
+dev = [
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "pre-commit", specifier = ">=3.6.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "rich", specifier = ">=13.7.0" },
+    { name = "ruff", specifier = ">=0.1.0" },
+    { name = "ty", specifier = ">=0.0.7" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.5.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
 ]
 
 [[package]]
@@ -330,55 +346,6 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.7" },
 ]
 provides-extras = ["dev", "cli", "confiture"]
-
-[[package]]
-name = "fraiseql-seed"
-version = "0.1.4"
-source = { virtual = "." }
-dependencies = [
-    { name = "fraiseql-data" },
-    { name = "fraiseql-uuid" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "click" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "rich" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fraiseql-data", editable = "packages/fraiseql-data" },
-    { name = "fraiseql-uuid", editable = "packages/fraiseql-uuid" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "click", specifier = ">=8.1.0" },
-    { name = "pre-commit", specifier = ">=3.6.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "rich", specifier = ">=13.7.0" },
-    { name = "ruff", specifier = ">=0.1.0" },
-    { name = "ty", specifier = ">=0.0.7" },
-]
-docs = [
-    { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-material", specifier = ">=9.5.0" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
-]
 
 [[package]]
 name = "fraiseql-uuid"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,0 @@
-{
-  "version": "0.1.4",
-  "commit": "35469ea",
-  "branch": "feat/generator-context-enrichment",
-  "timestamp": "2026-05-27T09:45:00Z"
-}


### PR DESCRIPTION
## Summary

Replaces the `version.json`-gated `dev/staging/main` deploy flow with **release-please** driving per-package release PRs. This is the structural fix for issue #24 — the bug where bumping a package's `pyproject.toml` without `version.json` silently skipped the publish step.

After this PR merges, releases work like:

```
conventional commit on main
  └─ release-please opens release PR per package needing a bump
      └─ human reviews + merges release PR
          └─ tag (e.g. fraiseql-data-v0.1.5) + GitHub Release published
              └─ deploy.yml fires on `release: published` → publishes that one package to PyPI
```

## What's in the diff

### New
- `release-please-config.json` — config: 2 packages, conventional-commits sections, full-package-name tags.
- `.release-please-manifest.json` — bootstrap state matching live PyPI (`uuid 0.1.3`, `data 0.1.4`).
- `.github/workflows/release-please.yml` — fires on push to main. Uses `secrets.RELEASE_PLEASE_TOKEN` (fine-grained PAT) — `GITHUB_TOKEN` would NOT trigger `quality-gate` on release PRs.

### Modified
- `deploy.yml` — full rewrite. Triggered by `release: published`. Parses tag → package → builds + publishes that one package. `tomllib`-based version check (not brittle grep).
- `quality-gate.yml`, `security-compliance.yml`, `test.yml` — drop `dev` from triggers.
- **`quality-gate.yml` + `security-compliance.yml` also drop the `name:` field from the gate jobs** — the check_runs were named `Quality Gate ✅` / `Security Gate ✅` (with emoji), but the branch protection requires contexts `quality-gate` / `security-gate`. These never matched, meaning every merge to main has been silently using admin bypass. Now they match. (Resolves Task #9 from the migration plan.)
- `pyproject.toml` (root) — drop `[project]` table. Root is a uv workspace marker, not a publishable package; no version to drift.

### Deleted
- `version.json` — replaced by `.release-please-manifest.json`.

## Cutover state

Step 0 already merged: `fraiseql-data 0.1.4` shipped via the old mechanism (#27). PyPI = manifest = `pyproject.toml` for both packages. This PR (Step 1) is the actual migration.

After merge:
- `release-please.yml` runs. Manifest matches PyPI → no release PR opens.
- Next `feat:`/`fix:` commit produces a release PR for the affected package.

`dev` and `staging` branches are no longer referenced by any workflow. Their deletion is the final cleanup step (Step 4) once this is verified working.

## Test plan
- [ ] `quality-gate` job runs on this PR and passes — and is reported as `quality-gate` (no emoji), so branch-protection check matching can be verified once merged.
- [ ] `security-gate` job same.
- [ ] `test.yml` and other workflows still trigger correctly.
- [ ] Local `uv sync` works without `[project]` in root pyproject.toml (verified manually).
- [ ] After merge: `release-please.yml` fires on main push, opens no PR (manifest = live state).
- [ ] After merge: confirm a subsequent feat-commit produces a release PR.

## Follow-up
- Step 4: delete `dev` and `staging` remote branches.
- Plan doc lives at `/tmp/release-please-migration/PLAN.md` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)