### PR TITLE
chore: anchor release-please at post-migration HEAD

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write       # create tags, releases, commit manifest updates

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,11 +22,13 @@
   "packages": {
     "packages/fraiseql-uuid": {
       "package-name": "fraiseql-uuid",
-      "component": "fraiseql-uuid"
+      "component": "fraiseql-uuid",
+      "last-release-sha": "c79bc28f65f4a52042e692fbec6fc57621385e2c"
     },
     "packages/fraiseql-data": {
       "package-name": "fraiseql-data",
-      "component": "fraiseql-data"
+      "component": "fraiseql-data",
+      "last-release-sha": "c79bc28f65f4a52042e692fbec6fc57621385e2c"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes the noisy first-run of release-please after PR #28.

## Background

After #28 merged, the new `release-please` workflow ran on main and opened
two release PRs (#29 closed, #30 closed) proposing **0.2.0** for both
`fraiseql-uuid` and `fraiseql-data`. Reason: no per-package tags exist
yet (the old `v0.1.2`/`v0.1.3`/`v0.1.4` tags don't match the new
`<package>-v<X.Y.Z>` scheme), and no `last-release-sha` was set in the
config, so release-please scanned the **entire repo history** and found
old `feat:` commits like "Initial monorepo structure" — enough to trigger
a MINOR bump under `bump-minor-pre-major: true`.

This is the exact noisy-first-run scenario flagged in D5 of the migration
plan; the plan said we'd add `last-release-sha` retroactively if needed.

## Changes

- `release-please-config.json` — adds `last-release-sha: c79bc28...` (the
  merge commit of #28) to both package entries. release-please will only
  scan commits AFTER that anchor going forward.
- `.github/workflows/release-please.yml` — adds `workflow_dispatch:` so we
  can manually trigger the workflow after this lands to verify it produces
  no PR.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge: `gh workflow run release-please.yml` (or trigger via UI).
- [ ] Verify release-please completes successfully and opens **no** release PR.
- [ ] First subsequent `feat:` or `fix:` commit on main should correctly produce a release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)